### PR TITLE
added stripe address form functionality

### DIFF
--- a/Website/src/components/AddressForm.jsx
+++ b/Website/src/components/AddressForm.jsx
@@ -1,0 +1,44 @@
+import { AddressElement, useElements, useStripe } from "@stripe/react-stripe-js"
+import { useState } from "react"
+
+const ADDRESS_OPTIONS = {
+    mode: 'shipping',
+  allowedCountries: ['US'],
+  blockPoBox: true,
+  fields: {
+    phone: 'always',
+  },
+  validation: {
+    phone: {
+      required: 'never',
+    },
+  },
+}
+
+export default function AddressForm() {
+    const stripe = useStripe();
+    const elements = useElements()
+
+    const handleNextStep = async () => {
+        const addressElement = elements.getElement('address');
+        const { complete, value } = await addressElement.getValue();
+        if (complete) {
+            console.log(value)
+        }
+    }
+
+    const handleSubmit = async (event) => {
+        event.preventDefault();
+        // Perform any additional processing and submit the form
+        // Could use stripe and elements here for card processing.
+    }
+
+    return (
+        <form onSubmit={handleSubmit}>
+            <h3> Shipping </h3>
+            <AddressElement onChange={handleNextStep} 
+            options={ADDRESS_OPTIONS} />
+            <button type="submit">Submit</button>
+        </form>
+    )
+}

--- a/Website/src/components/PaymentForm.jsx
+++ b/Website/src/components/PaymentForm.jsx
@@ -24,11 +24,15 @@ const CARD_OPTIONS = {
 	}
 }
 
-
-export default function PaymentForm() {
+export default function PaymentForm( cart ) {
     const [ success, setSuccess ] = useState(false)
     const stripe = useStripe()
     const elements = useElements()
+    // const [ userData, setUserData ] = useState({
+    //     name: '',
+    //     email: '',
+    //     address: ''
+    // })
 
     const handleSubmit = async (e) => {
         e.preventDefault()

--- a/Website/src/components/StripeContainer.jsx
+++ b/Website/src/components/StripeContainer.jsx
@@ -1,6 +1,7 @@
-import { Elements } from "@stripe/react-stripe-js"
+import { AddressElement, Elements } from "@stripe/react-stripe-js"
 import { loadStripe } from "@stripe/stripe-js"
 import PaymentForm from "./PaymentForm"
+import AddressForm from "./AddressForm"
 
 
 const PUBLIC_KEY = "pk_test_51NuGw5KZCAOFj1bCpDtNhlUapJsGvWn62c4fD4NzMSm5N5GE2IOQqV5YvFcL0ZKTN0MJXgBniMRylh4MoTqEn4tQ00pUGjUaPy"
@@ -11,7 +12,8 @@ export default function StripeContainer() {
 
     return (
         <Elements stripe={stripeTestPromise}>
-
+            <h2> Checkout </h2>
+            <AddressForm />
             <PaymentForm />
 
         </Elements>


### PR DESCRIPTION
added AddressForm component with stripe autofill functionality - does not hold cart state but will log address data for use in checking out with stripe in a single-page checkout flow when the backend is implemeneted